### PR TITLE
Add comprehensive admin sidebar navigation and detail pages

### DIFF
--- a/app/admin/banners/page.tsx
+++ b/app/admin/banners/page.tsx
@@ -1,8 +1,41 @@
-"use client";
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const banners = [
+  { id: 1, title: "Summer Sale", status: "Active" },
+  { id: 2, title: "New Arrivals", status: "Scheduled" }
+]
+
 export default function BannersPage() {
-    return (
-        <main>
-            <h1>Banners Management Page</h1>
-        </main>
-    );
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Banners</h1>
+          <p className="text-gray-600 text-sm">Manage hero banners currently live on the storefront.</p>
+        </header>
+
+        <Card>
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="py-2">Title</th>
+                <th className="py-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {banners.map((banner) => (
+                <tr key={banner.id} className="border-t border-gray-200">
+                  <td className="py-3 font-medium text-gray-800">{banner.title}</td>
+                  <td className="py-3">{banner.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
 }

--- a/app/admin/categories/page.tsx
+++ b/app/admin/categories/page.tsx
@@ -1,8 +1,41 @@
-"use client";
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const categories = [
+  { id: 1, name: "Electronics", products: 128 },
+  { id: 2, name: "Fashion", products: 86 }
+]
+
 export default function CategoriesPage() {
-    return (
-        <main>
-            <h1>Categories Management Page</h1>
-        </main>
-    );
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Categories</h1>
+          <p className="text-gray-600 text-sm">Group products into collections to simplify browsing.</p>
+        </header>
+
+        <Card>
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="py-2">Name</th>
+                <th className="py-2">Products</th>
+              </tr>
+            </thead>
+            <tbody>
+              {categories.map((category) => (
+                <tr key={category.id} className="border-t border-gray-200">
+                  <td className="py-3 font-medium text-gray-800">{category.name}</td>
+                  <td className="py-3">{category.products}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
 }

--- a/app/admin/customers/detail/page.tsx
+++ b/app/admin/customers/detail/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const customer = {
+  name: "Fatima Al Hosani",
+  email: "fatima@tojar.ae",
+  phone: "+971 50 123 4567",
+  totalOrders: 12,
+  totalSpent: 2894.5,
+  addresses: [
+    "Villa 12, Palm Jumeirah, Dubai",
+    "Office 402, Business Bay, Dubai"
+  ]
+}
+
+export default function CustomerDetailPage() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">{customer.name}</h1>
+          <p className="text-gray-600 text-sm">Comprehensive view of a customer's activity.</p>
+        </header>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card>
+            <h2 className="text-xl font-semibold mb-4">Profile</h2>
+            <dl className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="font-medium text-gray-700">Email</dt>
+                <dd>{customer.email}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium text-gray-700">Phone</dt>
+                <dd>{customer.phone}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium text-gray-700">Total Orders</dt>
+                <dd>{customer.totalOrders}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium text-gray-700">Total Spent</dt>
+                <dd>${customer.totalSpent.toFixed(2)}</dd>
+              </div>
+            </dl>
+          </Card>
+
+          <Card>
+            <h2 className="text-xl font-semibold mb-4">Addresses</h2>
+            <ul className="space-y-2 text-sm text-gray-700">
+              {customer.addresses.map((address) => (
+                <li key={address}>{address}</li>
+              ))}
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/app/admin/customers/page.tsx
+++ b/app/admin/customers/page.tsx
@@ -1,8 +1,43 @@
-"use client";
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const customers = [
+  { id: 1, name: "Fatima Al Hosani", email: "fatima@tojar.ae", orders: 12 },
+  { id: 2, name: "Omar Al Ali", email: "omar@tojar.ae", orders: 4 }
+]
+
 export default function CustomersPage() {
-    return (
-        <main>
-            <h1>Customers Management Page</h1>
-        </main>
-    );
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Customers</h1>
+          <p className="text-gray-600 text-sm">View shopper activity and engagement levels.</p>
+        </header>
+
+        <Card>
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="py-2">Name</th>
+                <th className="py-2">Email</th>
+                <th className="py-2">Orders</th>
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map((customer) => (
+                <tr key={customer.id} className="border-t border-gray-200">
+                  <td className="py-3 font-medium text-gray-800">{customer.name}</td>
+                  <td className="py-3">{customer.email}</td>
+                  <td className="py-3">{customer.orders}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
 }

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,9 +1,34 @@
-﻿"use client"
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const metrics = [
+  { label: "Total Revenue", value: "AED 128,500" },
+  { label: "Orders", value: "412" },
+  { label: "New Customers", value: "58" }
+]
+
 export default function DashboardPage() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
-      <p>Welcome to the admin dashboard.</p>
-    </div>
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Admin Dashboard</h1>
+          <p className="text-gray-600 text-sm">
+            High-level overview of performance across the marketplace.
+          </p>
+        </header>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {metrics.map((metric) => (
+            <Card key={metric.label} className="text-center">
+              <p className="text-sm uppercase tracking-wide text-gray-500">{metric.label}</p>
+              <p className="mt-2 text-2xl font-semibold text-gray-900">{metric.value}</p>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </AdminLayout>
   )
 }

--- a/app/admin/orders/detail/page.tsx
+++ b/app/admin/orders/detail/page.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const order = {
+  id: 101,
+  customer: "user@example.com",
+  status: "Paid",
+  total: 128.0,
+  placedAt: "2024-05-19 14:23",
+  items: [
+    { name: "Smartphone", quantity: 1, price: 599 },
+    { name: "Protective Case", quantity: 1, price: 29 }
+  ],
+  shippingAddress: "123 Palm Street, Dubai, UAE"
+}
+
+export default function OrderDetailPage() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Order #{order.id}</h1>
+          <p className="text-gray-600">Placed on {order.placedAt}</p>
+        </header>
+
+        <Card>
+          <h2 className="text-xl font-semibold mb-4">Customer</h2>
+          <dl className="grid grid-cols-1 gap-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-700">Email</dt>
+              <dd>{order.customer}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-700">Status</dt>
+              <dd>{order.status}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="font-medium text-gray-700">Total</dt>
+              <dd>${order.total.toFixed(2)}</dd>
+            </div>
+          </dl>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold mb-4">Items</h2>
+          <ul className="space-y-2">
+            {order.items.map((item) => (
+              <li key={item.name} className="flex justify-between text-sm">
+                <span>
+                  {item.quantity} × {item.name}
+                </span>
+                <span>${item.price.toFixed(2)}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+
+        <Card>
+          <h2 className="text-xl font-semibold mb-2">Shipping</h2>
+          <p className="text-sm text-gray-700">{order.shippingAddress}</p>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,10 +1,11 @@
 'use client'
+import Link from 'next/link'
 import AdminLayout from '@/components/ui/AdminLayout'
 import Card from '@/components/ui/Card'
 
 export default function OrdersPage() {
   const orders = [
-    { id: 101, user: 'user@example.com', total: 128.00, status: 'paid' },
+    { id: 101, user: 'user@example.com', total: 128.0, status: 'paid' },
     { id: 102, user: 'guest@example.com', total: 49.99, status: 'pending' }
   ]
 
@@ -19,6 +20,7 @@ export default function OrdersPage() {
               <th>User</th>
               <th>Total</th>
               <th>Status</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -26,8 +28,13 @@ export default function OrdersPage() {
               <tr key={o.id}>
                 <td className="py-2">{o.id}</td>
                 <td>{o.user}</td>
-                <td>${o.total}</td>
+                <td>${o.total.toFixed(2)}</td>
                 <td>{o.status}</td>
+                <td>
+                  <Link className="text-sm text-blue-600 hover:underline" href="/admin/orders/detail">
+                    View
+                  </Link>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/app/admin/payments/settings/page.tsx
+++ b/app/admin/payments/settings/page.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const gateways = [
+  { name: "Stripe", enabled: true, currency: "AED" },
+  { name: "PayPal", enabled: false, currency: "USD" }
+]
+
+export default function PaymentSettingsPage() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Payment Gateway Settings</h1>
+          <p className="text-gray-600 text-sm">
+            Manage which payment providers are available to customers.
+          </p>
+        </header>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          {gateways.map((gateway) => (
+            <Card key={gateway.name} className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold">{gateway.name}</h2>
+                  <p className="text-sm text-gray-600">Primary currency: {gateway.currency}</p>
+                </div>
+                <span
+                  className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                    gateway.enabled ? "bg-green-100 text-green-700" : "bg-gray-200 text-gray-600"
+                  }`}
+                >
+                  {gateway.enabled ? "Enabled" : "Disabled"}
+                </span>
+              </div>
+              <button className="rounded bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700">
+                Configure
+              </button>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/app/admin/promotions/codes/page.tsx
+++ b/app/admin/promotions/codes/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const promoCodes = [
+  { code: "WELCOME10", discount: "10%", status: "Active", uses: 124 },
+  { code: "FREESHIP", discount: "Free Shipping", status: "Draft", uses: 48 },
+  { code: "RAMADAN25", discount: "25%", status: "Expired", uses: 310 }
+]
+
+export default function PromoCodesPage() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Promotion Codes</h1>
+          <p className="text-gray-600 text-sm">Track and manage discount codes available to shoppers.</p>
+        </header>
+
+        <Card>
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="py-2">Code</th>
+                <th className="py-2">Discount</th>
+                <th className="py-2">Status</th>
+                <th className="py-2">Total Uses</th>
+              </tr>
+            </thead>
+            <tbody>
+              {promoCodes.map((promo) => (
+                <tr key={promo.code} className="border-t border-gray-200">
+                  <td className="py-3 font-medium text-gray-800">{promo.code}</td>
+                  <td className="py-3">{promo.discount}</td>
+                  <td className="py-3">
+                    <span
+                      className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                        promo.status === "Active"
+                          ? "bg-green-100 text-green-700"
+                          : promo.status === "Draft"
+                          ? "bg-yellow-100 text-yellow-700"
+                          : "bg-gray-200 text-gray-600"
+                      }`}
+                    >
+                      {promo.status}
+                    </span>
+                  </td>
+                  <td className="py-3">{promo.uses}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/app/admin/staff/page.tsx
+++ b/app/admin/staff/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const staffMembers = [
+  { id: 1, name: "Aisha Al Nuaimi", role: "Store Manager", email: "aisha@tojar.ae" },
+  { id: 2, name: "Mohammed Al Farsi", role: "Operations", email: "mohammed@tojar.ae" },
+  { id: 3, name: "Layla Al Mansoori", role: "Marketing", email: "layla@tojar.ae" }
+]
+
+export default function StaffPage() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Staff Users</h1>
+          <p className="text-gray-600 text-sm">Manage administrative access for your internal team.</p>
+        </header>
+
+        <Card>
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="py-2">Name</th>
+                <th className="py-2">Role</th>
+                <th className="py-2">Email</th>
+                <th className="py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {staffMembers.map((member) => (
+                <tr key={member.id} className="border-t border-gray-200">
+                  <td className="py-3 font-medium text-gray-800">{member.name}</td>
+                  <td className="py-3">{member.role}</td>
+                  <td className="py-3">{member.email}</td>
+                  <td className="py-3">
+                    <button className="rounded border border-gray-300 px-3 py-1 text-xs font-medium hover:bg-gray-50">
+                      Manage
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/app/admin/tax/page.tsx
+++ b/app/admin/tax/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import AdminLayout from "@/components/ui/AdminLayout"
+import Card from "@/components/ui/Card"
+
+const taxRates = [
+  { region: "UAE", rate: 5 },
+  { region: "KSA", rate: 15 },
+  { region: "Kuwait", rate: 0 }
+]
+
+export default function TaxSettingsPage() {
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        <header>
+          <h1 className="text-3xl font-semibold mb-2">Tax Settings</h1>
+          <p className="text-gray-600 text-sm">
+            Configure VAT and regional taxes for your marketplaces.
+          </p>
+        </header>
+
+        <Card>
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="py-2">Region</th>
+                <th className="py-2">Rate</th>
+                <th className="py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {taxRates.map((tax) => (
+                <tr key={tax.region} className="border-t border-gray-200">
+                  <td className="py-3 font-medium text-gray-800">{tax.region}</td>
+                  <td className="py-3">{tax.rate}%</td>
+                  <td className="py-3">
+                    <button className="rounded border border-gray-300 px-3 py-1 text-xs font-medium hover:bg-gray-50">
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/components/admin/Sidebar.tsx
+++ b/components/admin/Sidebar.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Image from "next/image"
+import Link from "next/link"
+
+import Logo from "@/public/images/logo-green.png"
+
+const navigation = [
+  { href: "/admin/dashboard", label: "Dashboard" },
+  { href: "/admin/orders", label: "Orders" },
+  { href: "/admin/orders/detail", label: "Order Detail" },
+  { href: "/admin/payments/settings", label: "Payment Gateway" },
+  { href: "/admin/tax", label: "Tax Settings" },
+  { href: "/admin/staff", label: "Staff Users" },
+  { href: "/admin/promotions", label: "Promotions" },
+  { href: "/admin/promotions/codes", label: "Promo Codes" },
+  { href: "/admin/banners", label: "Banners" },
+  { href: "/admin/faqs", label: "FAQs" },
+  { href: "/admin/categories", label: "Categories" },
+  { href: "/admin/customers", label: "Customers" },
+  { href: "/admin/customers/detail", label: "Customer Detail" }
+]
+
+export default function AdminSidebar() {
+  return (
+    <aside className="w-64 bg-gray-800 text-white min-h-screen p-6">
+      <Link href="/" className="flex items-center space-x-2 mb-8">
+        <Image src={Logo} alt="Tojar Admin" width={32} height={32} />
+        <span className="text-xl font-semibold">Tojar Admin</span>
+      </Link>
+      <nav className="space-y-3">
+        {navigation.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="block text-sm font-medium text-gray-200 transition hover:text-white"
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  )
+}

--- a/components/ui/AdminLayout.tsx
+++ b/components/ui/AdminLayout.tsx
@@ -1,28 +1,12 @@
 'use client'
-import Link from 'next/link'
-import Image from 'next/image'
-import Logo from '@/public/images/logo-green.png'
+
+import AdminSidebar from '@/components/admin/Sidebar'
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen">
-      <aside className="w-64 bg-gray-800 text-white p-6 space-y-4">
-        <Link href="/" className="flex items-center space-x-2 mb-6">
-          <Image src={Logo} alt="Tojar Logo" width={28} height={28} />
-          <span className="text-lg font-bold">Tojar Admin</span>
-        </Link>
-        <nav className="space-y-2">
-          <Link href="/admin/dashboard" className="block hover:underline">Dashboard</Link>
-          <Link href="/admin/products" className="block hover:underline">Products</Link>
-          <Link href="/admin/categories" className="block hover:underline">Categories</Link>
-          <Link href="/admin/promotions" className="block hover:underline">Promotions</Link>
-          <Link href="/admin/banners" className="block hover:underline">Banners</Link>
-          <Link href="/admin/faqs" className="block hover:underline">FAQs</Link>
-          <Link href="/admin/orders" className="block hover:underline">Orders</Link>
-          <Link href="/admin/customers" className="block hover:underline">Customers</Link>
-        </nav>
-      </aside>
-      <main className="flex-1 p-8 bg-gray-50">{children}</main>
+    <div className="flex min-h-screen bg-gray-100">
+      <AdminSidebar />
+      <main className="flex-1 p-8">{children}</main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a reusable admin sidebar component and integrate it into the Admin layout
- expand admin pages with richer placeholder content and new sections for orders, payments, tax, staff, and customer details
- enhance existing admin listings with consistent layouts and navigation links

## Testing
- npm run lint *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dff11c3150832e9297ff4284c02d6d